### PR TITLE
Optional number formatting function

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -17,8 +17,14 @@
       <h4 class="text-xl mb-2">Manually set a number</h4>
       <div class="border-b w-full h-px mb-4"></div>
       <div id="number-flip-2" class="mb-2 h-7"></div>
-      <input id="number-input" type="number" class="border rounded-sm px-2 py-1 mr-2" placeholder="Number" />
-      <button id="button" class="bg-blue-500 text-white px-4 py-1 rounded-sm hover:bg-blue-600">Set number</button>
+      <input id="number-input-2" type="number" class="border rounded-sm px-2 py-1 mr-2" placeholder="Number" />
+      <button id="button-2" class="bg-blue-500 text-white px-4 py-1 rounded-sm hover:bg-blue-600">Set number</button>
+      <div class="my-8"></div>
+      <h4 class="text-xl mb-2">Manually set a number with formattig function</h4>
+      <div class="border-b w-full h-px mb-4"></div>
+      <div id="number-flip-3" class="mb-2 h-7"></div>
+      <input id="number-input-3" type="number" class="border rounded-sm px-2 py-1 mr-2" placeholder="Number" />
+      <button id="button-3" class="bg-blue-500 text-white px-4 py-1 rounded-sm hover:bg-blue-600">Set number</button>
     </div>
     <script type="module" src="./index.js"></script>
   </body>

--- a/examples/index.js
+++ b/examples/index.js
@@ -14,11 +14,28 @@ setInterval(setRandomNumber, 2000);
 
 // Example 2: Manually set number (existing code)
 const numberFlip2 = new NumberFlip({ rootElement: document.getElementById('number-flip-2'), initialNumber: 12345 });
-const numberInput = document.getElementById('number-input');
-const button = document.getElementById('button');
-button.addEventListener('click', changeNumber);
+const numberInput2 = document.getElementById('number-input-2');
+const button2 = document.getElementById('button-2');
+button2.addEventListener('click', changeNumber2);
 
-function changeNumber() {
-  let newNumber = numberInput.value;
+function changeNumber2() {
+  let newNumber = numberInput2.value;
   numberFlip2.setNumber(newNumber);
+}
+
+// Example 3: Manually set number (existing code)
+const numberFlip3 = new NumberFlip({
+  rootElement: document.getElementById('number-flip-3'),
+  initialNumber: 2.145,
+  numberFormatter: (number) => {
+    return parseFloat(number).toFixed(6);
+  },
+});
+const numberInput3 = document.getElementById('number-input-3');
+const button3 = document.getElementById('button-3');
+button3.addEventListener('click', changeNumber3);
+
+function changeNumber3() {
+  let newNumber = numberInput3.value;
+  numberFlip3.setNumber(newNumber);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export class NumberFlip {
 
     this.rootElement.style.display = 'flex';
 
-    if (initialNumber) {
+    if (initialNumber !== undefined) {
       this.setNumber(initialNumber, animateInitialNumber);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
+type Formatter = (num: number) => string;
+
 export class NumberFlip {
   private rootElement: HTMLElement;
   private durationSlide: number;
   private durationFade: number;
+  private numberFormatter: Formatter;
   private decimalSeparator: string;
   private wrapperClassname: string;
   private digitClassname: string;
@@ -12,6 +15,7 @@ export class NumberFlip {
     durationFade = 200,
     initialNumber,
     animateInitialNumber = true,
+    numberFormatter = (num) => num.toString(),
     decimalSeparator = '.',
     wrapperClassname = 'numberflip-digit-container',
     digitClassname = 'numberflip-digit-container-value',
@@ -21,6 +25,7 @@ export class NumberFlip {
     durationFade?: number;
     initialNumber?: number;
     animateInitialNumber?: boolean;
+    numberFormatter: Formatter;
     decimalSeparator?: string;
     wrapperClassname?: string;
     digitClassname?: string;
@@ -28,6 +33,7 @@ export class NumberFlip {
     this.rootElement = rootElement;
     this.durationSlide = durationSlide;
     this.durationFade = durationFade;
+    this.numberFormatter = numberFormatter;
     this.decimalSeparator = decimalSeparator;
     this.wrapperClassname = wrapperClassname;
     this.digitClassname = digitClassname;
@@ -113,7 +119,7 @@ export class NumberFlip {
   }
 
   private getDigitsOfNumber(num: number): (number | string)[] {
-    const digits = num.toString().split('');
+    const digits = this.numberFormatter(num).split('');
     return digits.map((char) => (char === '.' ? '.' : parseInt(char, 10)));
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-type Formatter = (num: number) => string;
+export type Formatter = (num: number) => string;
 
 export class NumberFlip {
   private rootElement: HTMLElement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export class NumberFlip {
     durationFade?: number;
     initialNumber?: number;
     animateInitialNumber?: boolean;
-    numberFormatter: Formatter;
+    numberFormatter?: Formatter;
     decimalSeparator?: string;
     wrapperClassname?: string;
     digitClassname?: string;


### PR DESCRIPTION
Hello,

thanks for the great package. I needed to use this to format currency value hence with a fixed number of decimals.

I added a numberFormatter optional parameter which defaults to `.toString` hence preserving backwards compatibility.

Also added a 3rd example with `.toFixed(6)`.

- `npm run lint`: OK
- `npm run format`: OK

Thanks