### PR TITLE
style: Added style support for decimal points

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "number-flip-animation",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "number-flip-animation",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "number-flip-animation",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "type": "module",
   "description": "Small typescript package for animating the change of a number using a flip/slide animation.",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,12 +56,12 @@ export class NumberFlip {
     while (countOfDigitContainers < numberOfDigits) {
       this.rootElement.insertAdjacentHTML(
         'beforeend',
-        `<div class="${this.wrapperClassname}">` +
-          /*
-            The span with visibility hidden is needed in order to make the parent element occupy enough space to display the digit.
-            Otherwise the parent would have a width and height of 0 due to the absolute position of the .numberflip-digit-container-value element
-          */
-          `<span style="visibility: hidden;">0</span>
+        `<div class="${this.wrapperClassname} ${String(num)[countOfDigitContainers] === '.' ? 'dot' : ''}">` +
+        /*
+          The span with visibility hidden is needed in order to make the parent element occupy enough space to display the digit.
+          Otherwise the parent would have a width and height of 0 due to the absolute position of the .numberflip-digit-container-value element
+        */
+        `<span style="visibility: hidden;">0</span>
             <div class="${this.digitClassname}" style="transform: translateY(-100%);">
                 <span>9</span>
                 <span>8</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,6 +4,12 @@
   position: relative;
   transition-property: opacity;
   transition-duration: 200ms; /* Could be ommitted. The duration is set dynamically  */
+  &.dot {
+    &,
+    & * {
+      width: 10px;
+    }
+  }
 }
 
 .numberflip-digit-container-value {


### PR DESCRIPTION
Added `.dot` class in `.numberflip-digit-container` to handle decimal point style. Also updated `index.ts` file to dynamically add `dot` class when generating number container so that decimal points can be displayed correctly.