### PR TITLE
fix: Remove redundant dot class names from number containers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export class NumberFlip {
     while (countOfDigitContainers < numberOfDigits) {
       this.rootElement.insertAdjacentHTML(
         'beforeend',
-        `<div class="${this.wrapperClassname} ${String(num)[countOfDigitContainers] === '.' ? 'dot' : ''}">` +
+        `<div class="${this.wrapperClassname}">` +
         /*
           The span with visibility hidden is needed in order to make the parent element occupy enough space to display the digit.
           Otherwise the parent would have a width and height of 0 due to the absolute position of the .numberflip-digit-container-value element
@@ -113,6 +113,8 @@ export class NumberFlip {
           digitContainer.style.transform = `translateY(${translate}%)`;
         }, 0);
       }
+
+      (digitContainer as any).parentNode.classList[digits[i] === '.' ? 'add' : 'remove']('dot');
     }
   }
 


### PR DESCRIPTION
Remove the logic of dot class names from the number container HTML and add or remove them dynamically when updating the number